### PR TITLE
fix: Reintroduce format variables in overview.json

### DIFF
--- a/dashboards/overview.json
+++ b/dashboards/overview.json
@@ -1400,7 +1400,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_receive_bytes_total{%(containerNetworkReceiveBytesTotalSelector)s}[$__rate_interval ])\n  )\n)",
+          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_receive_bytes_total{%(containerNetworkReceiveBytesTotalSelector)s}[$__rate_interval ])\n  )\n)" % $._config.dashboards,
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1412,7 +1412,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_transmit_bytes_total{%(containerNetworkTransmitBytesTotalSelector)s}[$__rate_interval ])\n  )\n)",
+          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_transmit_bytes_total{%(containerNetworkTransmitBytesTotalSelector)s}[$__rate_interval ])\n  )\n)" % $._config.dashboards,
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1465,7 +1465,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(certmanager_certificate_ready_status{%(clusterVariableSelector)s}, cluster)",
+          "query": "label_values(certmanager_certificate_ready_status{%(clusterVariableSelector)s}, cluster)" % $._config.dashboards,
           "refId": "Prometheus-cluster-Variable-Query"
         },
         "refresh": 2,

--- a/dashboards/overview.json
+++ b/dashboards/overview.json
@@ -131,7 +131,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (condition) (certmanager_certificate_ready_status{ })",
+          "expr": "sum by (condition) (certmanager_certificate_ready_status{%(certmanagerCertificateReadyStatusSelector)s})" % $._config.dashboards,
           "interval": "",
           "legendFormat": "{{ condition }}",
           "refId": "A"
@@ -199,7 +199,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "min(certmanager_certificate_expiration_timestamp_seconds{ } > 0) - time()",
+          "expr": "min(certmanager_certificate_expiration_timestamp_seconds{%(certmanagerCertificateExpirationTimestampSecondsSelector)s} > 0) - time()" % $._config.dashboards,
           "hide": false,
           "instant": true,
           "interval": "",
@@ -330,7 +330,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "label_join(avg by (name, namespace, condition, exported_namespace) (certmanager_certificate_ready_status{ } == 1), \"namespaced_name\", \"-\", \"namespace\", \"exported_namespace\", \"name\")",
+          "expr": "label_join(avg by (name, namespace, condition, exported_namespace) (certmanager_certificate_ready_status{%(certmanagerCertificateReadyStatusSelector)s} == 1), \"namespaced_name\", \"-\", \"namespace\", \"exported_namespace\", \"name\")" % $._config.dashboards,
           "format": "table",
           "instant": true,
           "interval": "",
@@ -341,7 +341,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "label_join(avg by (name, namespace, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds{ }) * 1000, \"namespaced_name\", \"-\", \"namespace\", \"exported_namespace\", \"name\")",
+          "expr": "label_join(avg by (name, namespace, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds{%(certmanagerCertificateExpirationTimestampSecondsSelector)s}) * 1000, \"namespaced_name\", \"-\", \"namespace\", \"exported_namespace\", \"name\")" % $._config.dashboards,
           "format": "table",
           "instant": true,
           "interval": "",
@@ -493,7 +493,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (controller) (\n  rate(certmanager_controller_sync_call_count{ }[$__rate_interval ])\n)",
+          "expr": "sum by (controller) (\n  rate(certmanager_controller_sync_call_count{%(certmanagerControllerSyncCallCountSelector)s}[$__rate_interval ])\n)" % $._config.dashboards,
           "interval": "",
           "legendFormat": "{{ controller }}",
           "refId": "A"
@@ -612,7 +612,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (method, path, status) (\n  rate(certmanager_http_acme_client_request_count{ }[$__rate_interval ])\n)",
+          "expr": "sum by (method, path, status) (\n  rate(certmanager_http_acme_client_request_count{%(certmanagerHttpAcmeClientRequestCountSelector)s}[$__rate_interval ])\n)" % $._config.dashboards,
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} {{ status }}",
           "refId": "A"
@@ -731,7 +731,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_sum{ }[$__rate_interval ]))\n/\nsum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_count{ }[$__rate_interval ]))",
+          "expr": "sum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_sum{%(certmanagerHttpAcmeClientRequestDurationSecondsSumSelector)s}[$__rate_interval ]))\n/\nsum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_count{%(certmanagerHttpAcmeClientRequestDurationSecondsCountSelector)s}[$__rate_interval ]))" % $._config.dashboards,
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} {{ status }}",
           "refId": "A"
@@ -911,7 +911,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (pod) (rate(container_cpu_usage_seconds_total{container=\"cert-manager\" }[$__rate_interval ]))",
+          "expr": "avg by (pod) (rate(container_cpu_usage_seconds_total{%(containerCPUUsageSecondsTotalSelector)s}[$__rate_interval ]))" % $._config.dashboards,
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -923,7 +923,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (pod) (kube_pod_container_resource_limits_cpu_cores{container=\"cert-manager\" })",
+          "expr": "avg by (pod) (kube_pod_container_resource_limits_cpu_cores{%(kubePodContainerResourceLimitsCpuCoresSelector)s})" % $._config.dashboards,
           "format": "time_series",
           "hide": true,
           "interval": "",
@@ -935,7 +935,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (pod) (kube_pod_container_resource_requests_cpu_cores{container=\"cert-manager\" })",
+          "expr": "avg by (pod) (kube_pod_container_resource_requests_cpu_cores{%(kubePodContainerResourceRequestsCpuCoresSelector)s})" % $._config.dashboards,
           "format": "time_series",
           "hide": true,
           "interval": "",
@@ -1068,7 +1068,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (pod) (\n  rate(container_cpu_cfs_throttled_periods_total{container=\"cert-manager\" }[$__rate_interval ])\n  /\n  rate(container_cpu_cfs_periods_total{container=\"cert-manager\" }[$__rate_interval ])\n)",
+          "expr": "avg by (pod) (\n  rate(container_cpu_cfs_throttled_periods_total{%(containerCpuCfsThrottledPeriodsTotalSelector)s}[$__rate_interval ])\n  /\n  rate(container_cpu_cfs_periods_total{%(containerCpuCfsPeriodsTotalSelector)s}[$__rate_interval ])\n)" % $._config.dashboards,
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1251,7 +1251,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (pod) (container_memory_usage_bytes{container=\"cert-manager\" })",
+          "expr": "avg by (pod) (container_memory_usage_bytes{%(containerMemoryUsageBytesSelector)s})" % $._config.dashboards,
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1263,7 +1263,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (pod) (kube_pod_container_resource_limits_memory_bytes{container=\"cert-manager\" })",
+          "expr": "avg by (pod) (kube_pod_container_resource_limits_memory_bytes{%(kubePodContainerResourceLimitsMemoryBytesSelector)s})" % $._config.dashboards,
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1274,7 +1274,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (pod) (kube_pod_container_resource_requests_memory_bytes{container=\"cert-manager\" })",
+          "expr": "avg by (pod) (kube_pod_container_resource_requests_memory_bytes{%(kubePodContainerResourceRequestsMemoryBytesSelector)s})" % $._config.dashboards,
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1400,7 +1400,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_receive_bytes_total{namespace=\"cert-manager\" }[$__rate_interval ])\n  )\n)",
+          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_receive_bytes_total{%(containerNetworkReceiveBytesTotalSelector)s}[$__rate_interval ])\n  )\n)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1412,7 +1412,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_transmit_bytes_total{namespace=\"cert-manager\" }[$__rate_interval ])\n  )\n)",
+          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_transmit_bytes_total{%(containerNetworkTransmitBytesTotalSelector)s}[$__rate_interval ])\n  )\n)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1465,7 +1465,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(certmanager_certificate_ready_status{ }, cluster)",
+          "query": "label_values(certmanager_certificate_ready_status{%(clusterVariableSelector)s}, cluster)",
           "refId": "Prometheus-cluster-Variable-Query"
         },
         "refresh": 2,


### PR DESCRIPTION
Hello,

Feature imusmanmalik/cert-manager-mixin#3 does not work since imusmanmalik/cert-manager-mixin#5 removed all the template string variables in `overview.json`
This PR intends to fix the regression by reintroducing these variables.


