### PR TITLE
feat: Add Cluster Selector to dashboard if multiCluster is enabled

### DIFF
--- a/dashboards/overview.json
+++ b/dashboards/overview.json
@@ -1459,7 +1459,7 @@
           "uid": "$datasource"
         },
         "definition": "",
-        "hide": 2,
+        "hide": if $._config.dashboards.enableMultiCluster then 0 else 2,
         "includeAll": false,
         "multi": false,
         "name": "cluster",


### PR DESCRIPTION
Add logic to enable the cluster selector on the dashboard if multiCluster is enabled in the mixin.