### PR TITLE
Conserve labels in query result, add selector support

### DIFF
--- a/alerts/absent.libsonnet
+++ b/alerts/absent.libsonnet
@@ -6,7 +6,7 @@
         {
           local alert = 'CertManagerAbsent',
           alert: alert,
-          expr: 'absent(up{job="%(certManagerJobLabel)s"})' % $._config,
+          expr: 'absent(up{%s})' % $._config.certManagerSelector,
           'for': '10m',
           labels: {
             severity: 'critical',

--- a/alerts/certificates.libsonnet
+++ b/alerts/certificates.libsonnet
@@ -7,9 +7,8 @@
           local alert = 'CertManagerCertExpirySoon',
           alert: alert,
           expr: |||
-            avg by (exported_namespace, namespace, name) (
-              certmanager_certificate_expiration_timestamp_seconds - time()
-            ) < (%s * 24 * 3600) # 21 days in seconds
+            certmanager_certificate_expiration_timestamp_seconds - time()
+            < (%s * 24 * 3600) # 21 days in seconds
           ||| % $._config.certManagerCertExpiryDays,
           'for': '1h',
           labels: {
@@ -26,9 +25,7 @@
           local alert = 'CertManagerCertNotReady',
           alert: alert,
           expr: |||
-            max by (name, exported_namespace, namespace, condition) (
-              certmanager_certificate_ready_status{condition!="True"} == 1
-            )
+            certmanager_certificate_ready_status{condition!="True"} == 1
           |||,
           'for': '10m',
           labels: {
@@ -45,7 +42,7 @@
           local alert = 'CertManagerHittingRateLimits',
           alert: alert,
           expr: |||
-            sum by (host) (
+            sum without (method, path) (
               rate(certmanager_http_acme_client_request_count{status="429"}[5m])
             ) > 0
           |||,

--- a/alerts/certificates.libsonnet
+++ b/alerts/certificates.libsonnet
@@ -7,9 +7,9 @@
           local alert = 'CertManagerCertExpirySoon',
           alert: alert,
           expr: |||
-            certmanager_certificate_expiration_timestamp_seconds - time()
+            certmanager_certificate_expiration_timestamp_seconds{%s} - time()
             < (%s * 24 * 3600) # 21 days in seconds
-          ||| % $._config.certManagerCertExpiryDays,
+          ||| % [$._config.certManagerSelector, $._config.certManagerCertExpiryDays],
           'for': '1h',
           labels: {
             severity: 'warning',
@@ -25,8 +25,8 @@
           local alert = 'CertManagerCertNotReady',
           alert: alert,
           expr: |||
-            certmanager_certificate_ready_status{condition!="True"} == 1
-          |||,
+            certmanager_certificate_ready_status{%s, condition!="True"} == 1
+          ||| % $._config.certManagerSelector,
           'for': '10m',
           labels: {
             severity: 'critical',
@@ -43,9 +43,9 @@
           alert: alert,
           expr: |||
             sum without (method, path) (
-              rate(certmanager_http_acme_client_request_count{status="429"}[5m])
+              rate(certmanager_http_acme_client_request_count{%s, status="429"}[5m])
             ) > 0
-          |||,
+          ||| % $._config.certManagerSelector,
           'for': '5m',
           labels: {
             severity: 'critical',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -2,7 +2,7 @@
 {
   _config+:: {
     certManagerCertExpiryDays: '21',
-    certManagerJobLabel: 'cert-manager',
+    certManagerSelector: 'job="cert-manager"',
     certManagerRunbookURLPattern: 'https://github.com/imusmanmalik/cert-manager-mixin/blob/main/RUNBOOK.md#%s',
     grafanaExternalUrl: 'https://grafana.example.com',
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -24,9 +24,9 @@ tests:
   # Cert expiry
   - interval: 1m
     input_series:
-      - series: certmanager_certificate_expiration_timestamp_seconds{namespace="cert-manager", exported_namespace="test", name="expired-ingress-cert", foo="bar"}
+      - series: certmanager_certificate_expiration_timestamp_seconds{job="cert-manager", namespace="cert-manager", exported_namespace="test", name="expired-ingress-cert", foo="bar"}
         values: 1814400+0x43200 # 21d in seconds, static for 30d of samples
-      - series: certmanager_certificate_expiration_timestamp_seconds{namespace="cert-manager", exported_namespace="test", name="90d-ingress-cert"}
+      - series: certmanager_certificate_expiration_timestamp_seconds{job="cert-manager", namespace="cert-manager", exported_namespace="test", name="90d-ingress-cert"}
         values: 7776000+0x43200 # 90d in seconds, static for 30d of samples
     alert_rule_test:
       - eval_time: 61m
@@ -34,6 +34,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
+              job: cert-manager
               exported_namespace: test
               namespace: cert-manager
               name: expired-ingress-cert
@@ -47,11 +48,11 @@ tests:
   # Cert not ready
   - interval: 1m
     input_series:
-      - series: certmanager_certificate_ready_status{namespace="cert-manager", exported_namespace="test", name="ready", condition="True"}
+      - series: certmanager_certificate_ready_status{job="cert-manager", namespace="cert-manager", exported_namespace="test", name="ready", condition="True"}
         values: 1+0x30
-      - series: certmanager_certificate_ready_status{namespace="cert-manager", exported_namespace="test", name="not ready", condition="False"}
+      - series: certmanager_certificate_ready_status{job="cert-manager", namespace="cert-manager", exported_namespace="test", name="not ready", condition="False"}
         values: 1+0x30
-      - series: certmanager_certificate_ready_status{namespace="cert-manager", exported_namespace="test", name="who knows", condition="Unknown"}
+      - series: certmanager_certificate_ready_status{job="cert-manager", namespace="cert-manager", exported_namespace="test", name="who knows", condition="Unknown"}
         values: 1+0x30
     alert_rule_test:
       - eval_time: 10m
@@ -59,6 +60,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
+              job: cert-manager
               exported_namespace: test
               namespace: cert-manager
               name: not ready
@@ -72,6 +74,7 @@ tests:
               runbook_url: "https://github.com/imusmanmalik/cert-manager-mixin/blob/main/RUNBOOK.md#certmanagercertnotready"
           - exp_labels:
               severity: critical
+              job: cert-manager
               exported_namespace: test
               namespace: cert-manager
               name: who knows
@@ -87,11 +90,11 @@ tests:
   # cert-manager rate limits
   - interval: 1m
     input_series:
-      - series: certmanager_http_acme_client_request_count{status="200", host="normal.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
+      - series: certmanager_http_acme_client_request_count{job="cert-manager", status="200", host="normal.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
         values: 1+1x30
-      - series: certmanager_http_acme_client_request_count{status="429", host="rate-limited.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
+      - series: certmanager_http_acme_client_request_count{job="cert-manager", status="429", host="rate-limited.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
         values: 1+1x30
-      - series: certmanager_http_acme_client_request_count{status="429", host="one-limited-request.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
+      - series: certmanager_http_acme_client_request_count{job="cert-manager", status="429", host="one-limited-request.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
         values: 1+0x30
     alert_rule_test:
       - eval_time: 10m
@@ -99,6 +102,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
+              job: cert-manager
               host: rate-limited.acme-v02.api.letsencrypt.org
               status: 429
             exp_annotations:

--- a/tests.yaml
+++ b/tests.yaml
@@ -37,6 +37,7 @@ tests:
               exported_namespace: test
               namespace: cert-manager
               name: expired-ingress-cert
+              foo: bar
             exp_annotations:
               summary: The cert `expired-ingress-cert` is 20d 22h 59m 0s from expiry, it should have renewed over a week ago.
               description: "The domain that this cert covers will be unavailable after 20d 22h 59m 0s. Clients using endpoints that this cert protects will start to fail in 20d 22h 59m 0s."
@@ -99,6 +100,7 @@ tests:
           - exp_labels:
               severity: critical
               host: rate-limited.acme-v02.api.letsencrypt.org
+              status: 429
             exp_annotations:
               summary: "Cert manager hitting LetsEncrypt rate limits."
               description: "Depending on the rate limit, cert-manager may be unable to generate certificates for up to a week."


### PR DESCRIPTION
I've been using your mixin for quite some time but ran into an issue when I implemented label based alerting. The certificate alert queries currently strip away all labels except for the ones select in the `by` clause.

Then I had a closer look at the queries and in my opinion you don't need the aggregations for `CertManagerCertExpirySoon` and `CertManagerCertNotReady`. The certificates are already unique through the namespace + name combination and it's not possible to group them, therefore I removed the aggregations.

For `CertManagerHittingRateLimits` I looked at the metric and from what I see `sum without (method, path)` should be sufficient for aggregation.

Last I would find it very useful to set a `selector` variable similar how it's done in other mixins, examples:

- https://github.com/prometheus/node_exporter/blob/master/docs/node-mixin/config.libsonnet#L11
- https://github.com/prometheus-operator/prometheus-operator/blob/main/jsonnet/mixin/config.libsonnet#L3
- https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/config.libsonnet#L20-L33

I refactored `certManagerJobLabel` to `certManagerSelector` and placed it in all alerts. I also updated the tests.