### PR TITLE
feat: make CertManagerCertExpirySoon dynamic and add namespace relabeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@
 
 The cert-manager mixin is a collection of reusable and configurable [Prometheus](https://prometheus.io/) alerts, and a [Grafana](https://grafana.com) dashboard to help with operating [cert-manager](https://cert-manager.io/).
 
-## Config Tweaks
+## Configuration Options
 
-There are some configurable options you may want to override in your usage of this mixin, as they will be specific to your deployment of cert-manager. They can be found in [config.libsonnet](config.libsonnet).
+See [config.libsonnet](config.libsonnet) for all available options. Some notable ones:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `certManagerCertExpiryRenewalElapsedThreshold` | `0.3` | Fraction of the renewal window that must elapse before `CertManagerCertExpirySoon` fires. Each certificate's renewal window is computed dynamically from `certmanager_certificate_expiration_timestamp_seconds - certmanager_certificate_renewal_timestamp_seconds`. A value of `0.3` means the alert fires once 30% of that window has passed without a successful renewal. |
+| `certManagerReplaceExportedNamespace` | `false` | When `true`, certificate alerts use `label_replace` to promote `exported_namespace` to `namespace` and drop the original `exported_namespace` label. This is useful when the `namespace` label should reflect the namespace where the certificate resource lives, rather than the namespace of the cert-manager controller itself. |
+| `enableMultiCluster` | `false` | Enable multi-cluster label selectors in alerts and dashboards. |
+| `clusterVariableSelector` | `''` | The label name used to distinguish clusters (e.g. `cluster`). Only effective when `enableMultiCluster` is `true`. |
 
 ## Using the mixin with kube-prometheus
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -16,7 +16,9 @@ This alert fires when there is no cert-manager endpoint discovered by Prometheus
 
 ## CertManagerCertExpirySoon
 
-A certificate that cert-manager is maintaining is due to expire within 21 days. Typically ACME certs are updated 30 days before expiry, so this is unusual.
+A certificate that cert-manager is maintaining has not been renewed within the expected timeframe. Rather than using a fixed expiry threshold, this alert dynamically computes each certificate's renewal window from `certmanager_certificate_expiration_timestamp_seconds - certmanager_certificate_renewal_timestamp_seconds` and fires once a configurable fraction of that window has elapsed (default: 30%, controlled by `certManagerCertExpiryRenewalElapsedThreshold`).
+
+This alert only fires for certificates that are currently in a **Ready** state (`certmanager_certificate_ready_status{condition="True"}`). Certificates that are not ready will trigger the separate `CertManagerCertNotReady` alert instead.
 
 Ensure the certificate issuer is configured correctly. Check cert-manager logs for errors renewing this certificate.
 

--- a/alerts/certificates.libsonnet
+++ b/alerts/certificates.libsonnet
@@ -5,19 +5,50 @@
       rules: [
         {
           local alert = 'CertManagerCertExpirySoon',
+          local clusterSel = if $._config.enableMultiCluster && $._config.clusterVariableSelector != '' then ', ' + $._config.clusterVariableSelector else '',
           alert: alert,
-          expr: |||
-            avg by (exported_namespace, namespace, name%s) (
-              certmanager_certificate_expiration_timestamp_seconds - time()
-            ) < (%s * 24 * 3600) # 21 days in seconds
-          ||| % [if $._config.enableMultiCluster && $._config.clusterVariableSelector != '' then ', ' + $._config.clusterVariableSelector else '', $._config.certManagerCertExpiryDays],
+          local remainingThreshold = '%g' % (1 - $._config.certManagerCertExpiryRenewalElapsedThreshold),
+          expr: if $._config.certManagerReplaceExportedNamespace then
+            |||
+              min without (exported_namespace) (
+                label_replace(
+                  avg by (exported_namespace, namespace, name%s) (
+                    (certmanager_certificate_expiration_timestamp_seconds - time())
+                    and on (exported_namespace, namespace, name%s)
+                    (certmanager_certificate_ready_status{condition="True"} == 1)
+                  ),
+                  "namespace", "$1", "exported_namespace", "(.*)"
+                )
+              )
+              <
+              min without (exported_namespace) (
+                label_replace(
+                  avg by (exported_namespace, namespace, name%s) (
+                    certmanager_certificate_expiration_timestamp_seconds - certmanager_certificate_renewal_timestamp_seconds
+                  ),
+                  "namespace", "$1", "exported_namespace", "(.*)"
+                )
+              ) * %s
+            ||| % [clusterSel, clusterSel, clusterSel, remainingThreshold]
+          else
+            |||
+              avg by (exported_namespace, namespace, name%s) (
+                (certmanager_certificate_expiration_timestamp_seconds - time())
+                and on (exported_namespace, namespace, name%s)
+                (certmanager_certificate_ready_status{condition="True"} == 1)
+              )
+              <
+              avg by (exported_namespace, namespace, name%s) (
+                certmanager_certificate_expiration_timestamp_seconds - certmanager_certificate_renewal_timestamp_seconds
+              ) * %s
+            ||| % [clusterSel, clusterSel, clusterSel, remainingThreshold],
           'for': '1h',
           labels: {
             severity: 'warning',
           },
           annotations:
             {
-              summary: 'The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from expiry, it should have renewed over a week ago.',
+              summary: 'The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from expiry, it should have been renewed by now.',
               description: 'The domain that this cert covers will be unavailable after {{ $value | humanizeDuration }}. Clients using endpoints that this cert protects will start to fail in {{ $value | humanizeDuration }}.',
             }
             + (if $._config.grafanaExternalUrlEnabled then {
@@ -29,12 +60,25 @@
         },
         {
           local alert = 'CertManagerCertNotReady',
+          local clusterSel = if $._config.enableMultiCluster && $._config.clusterVariableSelector != '' then ', ' + $._config.clusterVariableSelector else '',
           alert: alert,
-          expr: |||
-            max by (name, exported_namespace, namespace, condition%s) (
-              certmanager_certificate_ready_status{condition!="True"} == 1
-            )
-          ||| % (if $._config.enableMultiCluster && $._config.clusterVariableSelector != '' then ', ' + $._config.clusterVariableSelector else ''),
+          expr: if $._config.certManagerReplaceExportedNamespace then
+            |||
+              min without (exported_namespace) (
+                label_replace(
+                  max by (name, exported_namespace, namespace, condition%s) (
+                    certmanager_certificate_ready_status{condition!="True"} == 1
+                  ),
+                  "namespace", "$1", "exported_namespace", "(.*)"
+                )
+              )
+            ||| % clusterSel
+          else
+            |||
+              max by (name, exported_namespace, namespace, condition%s) (
+                certmanager_certificate_ready_status{condition!="True"} == 1
+              )
+            ||| % clusterSel,
           'for': '10m',
           labels: {
             severity: 'critical',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -3,12 +3,16 @@
   _config+:: {
     local cfg = self,
 
-    certManagerCertExpiryDays: '21',
+    // Fraction of the renewal window elapsed before alerting (0.3 = alert after 30% of renewal window has passed).
+    certManagerCertExpiryRenewalElapsedThreshold: 0.3,
     certManagerJobLabel: 'cert-manager',
     certManagerRunbookURLEnabled: true,
     certManagerRunbookURLPattern: 'https://github.com/imusmanmalik/cert-manager-mixin/blob/main/RUNBOOK.md#%s',
     grafanaExternalUrlEnabled: true,
     grafanaExternalUrl: 'https://grafana.example.com',
+
+    // When true, replaces exported_namespace with namespace in certificate alerts
+    certManagerReplaceExportedNamespace: false,
 
     enableMultiCluster: false,
     clusterVariableSelector: '',

--- a/tests.yaml
+++ b/tests.yaml
@@ -24,12 +24,25 @@ tests:
   # Cert expiry
   - interval: 1m
     input_series:
+      # Short-lived cert: expires in 2h, renewal starts at 30m → renewal window 1.5h
+      # Threshold = 1.5h * 0.7 = 63m. Fires when time_to_expiry < 63m, i.e. at t=57m+.
+      # With for: 1h, alert fires at ~118m when time_to_expiry = 2m.
       - series: certmanager_certificate_expiration_timestamp_seconds{namespace="cert-manager", exported_namespace="test", name="expired-ingress-cert", foo="bar"}
-        values: 1814400+0x43200 # 21d in seconds, static for 30d of samples
+        values: 7200+0x200
+      - series: certmanager_certificate_renewal_timestamp_seconds{namespace="cert-manager", exported_namespace="test", name="expired-ingress-cert", foo="bar"}
+        values: 1800+0x200
+      - series: certmanager_certificate_ready_status{namespace="cert-manager", exported_namespace="test", name="expired-ingress-cert", condition="True"}
+        values: 1+0x200
+      # Long-lived cert: expires in 90d, renewal at 60d → renewal window 30d
+      # Threshold = 30d * 0.7 = 21d. At t=118m, time_to_expiry ≈ 89.99d >> 21d → does not fire.
       - series: certmanager_certificate_expiration_timestamp_seconds{namespace="cert-manager", exported_namespace="test", name="90d-ingress-cert"}
-        values: 7776000+0x43200 # 90d in seconds, static for 30d of samples
+        values: 7776000+0x200
+      - series: certmanager_certificate_renewal_timestamp_seconds{namespace="cert-manager", exported_namespace="test", name="90d-ingress-cert"}
+        values: 5184000+0x200
+      - series: certmanager_certificate_ready_status{namespace="cert-manager", exported_namespace="test", name="90d-ingress-cert", condition="True"}
+        values: 1+0x200
     alert_rule_test:
-      - eval_time: 61m
+      - eval_time: 118m
         alertname: CertManagerCertExpirySoon
         exp_alerts:
           - exp_labels:
@@ -38,8 +51,8 @@ tests:
               namespace: cert-manager
               name: expired-ingress-cert
             exp_annotations:
-              summary: The cert `expired-ingress-cert` is 20d 22h 59m 0s from expiry, it should have renewed over a week ago.
-              description: "The domain that this cert covers will be unavailable after 20d 22h 59m 0s. Clients using endpoints that this cert protects will start to fail in 20d 22h 59m 0s."
+              summary: The cert `expired-ingress-cert` is 2m 0s from expiry, it should have been renewed by now.
+              description: "The domain that this cert covers will be unavailable after 2m 0s. Clients using endpoints that this cert protects will start to fail in 2m 0s."
               dashboard_url: https://grafana.example.com/d/TvuRo2iMk/cert-manager
               runbook_url: "https://github.com/imusmanmalik/cert-manager-mixin/blob/main/RUNBOOK.md#certmanagercertexpirysoon"
 


### PR DESCRIPTION
- Replace fixed `certManagerCertExpiryDays` with dynamic per-certificate
  threshold based on renewal window (`certManagerCertExpiryRenewalElapsedThreshold`)
- Only fire `CertManagerCertExpirySoon` for certificates in Ready state
- Add `certManagerReplaceExportedNamespace` option to promote
  `exported_namespace` to `namespace` in certificate alerts
- Update tests, README, and runbook accordingly